### PR TITLE
fix @babel/plugin-proposal-decorators build error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,10 +3,10 @@
     "@babel/preset-env", "@babel/preset-react"
   ],
   "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-transform-runtime",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }]
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,11 +59,11 @@ module.exports = {
             options: {
               presets: ["@babel/preset-env", "@babel/preset-react"],
               plugins: [
+                ["@babel/plugin-proposal-decorators", { "legacy": true }],
                 "@babel/plugin-proposal-class-properties",
                 "@babel/plugin-proposal-object-rest-spread",
                 "@babel/plugin-syntax-dynamic-import",
-                "@babel/plugin-transform-runtime",
-                ["@babel/plugin-proposal-decorators", { "legacy": true }]
+                "@babel/plugin-transform-runtime"
               ]
             }
           }]


### PR DESCRIPTION
This PR fixes the build error below. It moves the order of the @babel/plugin-proposal-decorators in two files. The error message was very prescriptive, so this was low hanging fruit!

Nice work on the project!

```
ERROR in ./src/container/App.jsx
Module build failed (from ./node_modules/babel-loader/lib/index.js):
SyntaxError: /puppetry/src/container/App.jsx: Decorators are not enabled.
If you are using ["@babel/plugin-proposal-decorators", { "legacy": true }], make sure it comes *before* "@babel/plugin-proposal-class-properties" and enable loose mode, like so:
	["@babel/plugin-proposal-decorators", { "legacy": true }]
	["@babel/plugin-proposal-class-properties", { "loose": true }]
  29 |       });
  30 | 
> 31 | @connect( mapStateToProps, mapDispatchToProps )
     | ^
  32 | export class App extends React.Component
```