### PR TITLE
Fix assertText not parsing template expressions

### DIFF
--- a/src/service/assert.js
+++ b/src/service/assert.js
@@ -74,7 +74,7 @@ export function justify( text ) {
 }
 
 function parseTpl( value, id, type ) {
-  if ( typeof type === "undefined" || type !== "string" ) {
+  if ( typeof type === "undefined" || !(type == "string" || type == "text") ) {
     return JSON.stringify( value );
   }
    // @see ./src/component/Schema/Params/Element/assertText.js


### PR DESCRIPTION
Fixes #90 as far as I can see.