### PR TITLE
Add template expression parsing for upload filepath

### DIFF
--- a/src/component/Schema/Params/Element/upload.js
+++ b/src/component/Schema/Params/Element/upload.js
@@ -1,18 +1,21 @@
 import { FILE, INPUT, INPUT_NUMBER } from "../../constants";
 import { renderTarget, result } from "service/utils";
 import fs from "fs";
+import ExpressionParser from "service/ExpressionParser";
 import { join } from "path";
 
 export const upload = {
-  template: ({ target, params, projectDirectory }) => {
-    const { path, name, size } = params,
-          resolvedPath = path ? ( fs.existsSync( path ) ? path : join( projectDirectory, path ) ) : null;
+  template: ({ id, target, params, projectDirectory }) => {
+    const { path, name, size } = params;
+    const parser = new ExpressionParser(id);
+    const expandedPath = parser.stringify( path ).replaceAll("`", "");
+    let resolvedPath = expandedPath ? ( fs.existsSync( expandedPath ) ? expandedPath : join( projectDirectory, expandedPath ) ) : null;
 
     return `
       // Upload input[type=file]
       ${ ( name && size )
     ? `result = util.generateTmpUploadFile( "${ name }", ${ size } );`
-    : `result = ${ JSON.stringify( resolvedPath ) };` }
+    : `result = \`${ resolvedPath }\`;` }
       await ( ${ renderTarget( target ) } ).uploadFile( result );`;
   },
 


### PR DESCRIPTION
Should solve issues in #78 (not for generated files but for normal filename).

We have the need to upload a number of different sample files and would like to make that happen using dynamic template variables. The upload method doesn't currently allow that.

I'm not sure if there is some other method than stringify + replaceAll I could be using here, so feel free to change things to be more in line with how you like the code-base to be.